### PR TITLE
Issue#3 fixing Redfish telemetry service configuration(UI) not to be needed to add the service with iDRAC details twice

### DIFF
--- a/cmd/idrac-telemetry-receiver.sh
+++ b/cmd/idrac-telemetry-receiver.sh
@@ -5,5 +5,7 @@ go run cmd/redfishread/redfishread.go &
 ## can be used for file based 
 ## discovery and authentication
 ## (look at sample config.ini for details)
-go run cmd/simpleauth/simpleauth.go &
-go run cmd/simpledisc/simpledisc.go
+go run cmd/dbdiscauth/dbdiscauth.go
+#go run cmd/simpleauth/simpleauth.go &
+#go run cmd/simpledisc/simpledisc.go
+


### PR DESCRIPTION
Issue#3 fixing Redfish telemetry service configuration(UI) not to be needed to add the service with iDRAC details twice