### PR TITLE
22 Kibana ports not forwarded

### DIFF
--- a/docker-compose-files/elastic-docker-pipeline-reference-unenc.yml
+++ b/docker-compose-files/elastic-docker-pipeline-reference-unenc.yml
@@ -68,6 +68,8 @@ services:
       ELASTICSEARCH_HOSTS: http://es01:9200
     networks:
       - elastic
+    ports:
+      - "5601:5601"
 
   activemq:
     image: rmohr/activemq:5.10.0 


### PR DESCRIPTION
- Fixes #22
- Add port forwarding for kibana to elastic-docker-pipeline-reference-unenc.yml

Signed-off-by: Grant Curell <grant_curell@dell.com>