### PR TITLE
52 The code base only supports docker-compose v2 and we do not check for that

### DIFF
--- a/docker-compose-files/compose.sh
+++ b/docker-compose-files/compose.sh
@@ -13,6 +13,57 @@ if [[ $# -eq 0 ]] ; then
     exit 0
 fi
 
+# Version check taken from this fine answer: https://stackoverflow.com/a/4025065/4427375
+# This is used to check if the docker compose version is sufficient.
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+testvercomp () {
+    vercomp $1 $2
+    case $? in
+        0) op='=';;
+        1) op='>';;
+        2) op='<';;
+    esac
+    if [[ $op != $3 ]]
+    then
+        echo "FAIL: Your docker compose version is $1. It must be 2.2.0 or higher!"
+        exit
+    else
+        echo "Pass: Docker compose version is $1."
+    fi
+}
+
+testvercomp $(docker-compose --version | cut -d ' ' -f 4 | sed 's/^v//') 2.2.0 '>'
+
 PROFILE_ARG="--profile core"
 BUILD_ARG=
 DETACH_ARG="-d"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -9,6 +9,7 @@
   - [Elasticsearch](#elasticsearch)
   - [Do for All Pipelines](#do-for-all-pipelines)
     - [Install Docker](#install-docker)
+    - [Install docker-compose](#install-docker-compose)
     - [Deploying the Framework](#deploying-the-framework)
     - [Post Install for Elasticsearch](#post-install-for-elasticsearch)
     - [Post Install for InfluxDB, Prometheus, or TimescaleDB](#post-install-for-influxdb-prometheus-or-timescaledb)
@@ -122,6 +123,11 @@ sudo usermod -aG docker $USER
 ```
 
 and then log out and back in. Run `docker run hello-world` as the user in question to test your privileges.
+
+### Install docker-compose
+
+You will also need to install docker-compose version 2. The code **will not work** with version 1. Instructions for 
+installing docker compose version 2 are [here](https://docs.docker.com/compose/cli-command/#installing-compose-v2).
 
 ### Deploying the Framework
 


### PR DESCRIPTION
- Updated compose.sh to check for docker version so that it will not run with out compose version 2
- Updated the install instructions to indicate the need for docker compose version 2
- Added a few notes for splunkpump
- Fixes #51
- Fixes #52

Signed-off-by: Grant Curell <grant_curell@dell.com>