### PR TITLE
If metric id has empty string, prometheus was panicking 

### DIFF
--- a/cmd/redfishread/redfishread.go
+++ b/cmd/redfishread/redfishread.go
@@ -72,9 +72,20 @@ func getValueIdContextAndLabel(value *redfish.RedfishPayload, i int) (string, st
 	id := ""
 	if value.Object["MetricId"] != nil {
 		id = value.Object["MetricId"].(string)
-	} else {
+		if id == "" && value.Object["MetricProperty"] != nil {
+			id = value.Object["MetricProperty"].(string)
+			//get last part of MP, /abc/def#ghi => def_ghi
+			li := strings.LastIndex(id, "/")
+			if li != -1 {
+				id = id[li+1:]
+			}
+			id = strings.ReplaceAll(id, "#", "_")
+		}
+	}
+	if id == "" {
 		id = fmt.Sprintf("Metric%d", i)
 	}
+
 	if value.Object["Oem"] != nil {
 		oem := value.Object["Oem"].(map[string]interface{})
 		if oem["Dell"] != nil {


### PR DESCRIPTION
Replacing the metric id with Metric Property /redfish/v1/Chassis/System.Embedded.1/Sensors/**CPU0Temp#Reading** 
The final metric id can be seen in screenshot

<img width="1600" height="135" alt="image" src="https://github.com/user-attachments/assets/821ef370-e6cf-4419-80fa-39895dbad4db" />
