### PR TITLE
Changes to support reconnection to a new broker in case the old broker connection is lost 

### DIFF
--- a/cmd/kafkapump/kafkapump.go
+++ b/cmd/kafkapump/kafkapump.go
@@ -1,259 +1,292 @@
-// Licensed to You under the Apache License, Version 2.0.
-
-package kafka
+package main
 
 import (
-        "context"
-        "crypto/tls"
-        "crypto/x509"
+        "encoding/json"
         "fmt"
-        "io"
         "log"
-        "net"
         "os"
+        "strconv"
         "strings"
         "sync"
         "time"
 
-        kafka "github.com/segmentio/kafka-go"
-
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/config"
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/databus"
         "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/kafka"
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/stomp"
 )
 
-const KafkaMaxMessageBytes = 16 * 1024
-
-type KafkaMessagebus struct {
-        conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
-        addr        string
-        ctx         context.Context
-        dialer      *kafka.Dialer
-        topicConnMu sync.RWMutex
+type kafkaEventFields struct {
+        Value      float64 `json:"_value"`
+        MetricName string  `json:"metric_name"`
+        Source     string  `json:"source"`
 }
 
-type KafkaSubscription struct {
+type kafkaEvent struct {
+        Time   int64            `json:"time"`
+        Event  string           `json:"event"`
+        Host   string           `json:"host"`
+        Fields kafkaEventFields `json:"fields"`
 }
 
-type KafkaTLSConfig struct {
-        ServerCA   string
-        ClientCert string
-        ClientKey  string
-        SkipVerify bool // skip hostname check
+var configStringsMu sync.RWMutex
+var configStrings = map[string]string{
+        "mbhost":          "activemq",
+        "mbport":          "61613",
+        "kafkaBroker":     "",
+        "kafkaTopic":      "",
+        "kafkaCACert":     "",
+        "kafkaClientCert": "",
+        "kafkaClientKey":  "",
+        "kafkaSkipVerify": "",
 }
 
-func NewKafkaMessageBus(host string, port int, topic string, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.addr = fmt.Sprintf("%s:%d", host, port)
-        ret.ctx = context.Background()
-        ret.conns = map[string]*kafka.Conn{}
-        ret.topicConnMu = sync.RWMutex{}
-
-        dialer := &kafka.Dialer{
-                Timeout:   10 * time.Second,
-                DualStack: true,
-        }
-
-        // TLS
-        if tlsCfg != nil && tlsCfg.ServerCA != "" {
-                ca, err := os.ReadFile(tlsCfg.ServerCA)
-                if err != nil {
-                        log.Println("failed to load server CA cert", err)
-                        return nil, err
-                }
-                pool := x509.NewCertPool()
-                if ok := pool.AppendCertsFromPEM(ca); !ok {
-                        log.Println("Unable to apppend cert to pool")
-                }
-
-                config := tls.Config{
-                        RootCAs:            pool,
-                        MinVersion:         tls.VersionTLS12,
-                        InsecureSkipVerify: tlsCfg.SkipVerify,
-                }
-
-                // Client Authentication - optional
-                if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
-                        ccrt, err := os.ReadFile(tlsCfg.ClientCert)
-                        if err != nil {
-                                log.Println("failed to load client cert", err)
-                                return nil, err
-                        }
-                        ckey, err := os.ReadFile(tlsCfg.ClientKey)
-                        if err != nil {
-                                log.Println("failed to load client key", err)
-                                return nil, err
-                        }
-                        cert, err := tls.X509KeyPair(ccrt, ckey)
-                        if err != nil {
-                                log.Println("X509KeyPair error ", err)
-                                return nil, err
-                        }
-                        config.Certificates = []tls.Certificate{cert}
-                }
-                dialer.TLS = &config
-        }
-
-        ret.dialer = dialer
-        if topic != "" {
-                conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
-
-                // ✅ Log the actual broker & partition we got connected to
-                log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
-
-                ret.topicConnMu.Lock()
-                ret.conns[topic] = conn
-                ret.topicConnMu.Unlock()
-        }
-
-        return messagebus.Messagebus(ret), nil
+var configItems = map[string]*config.ConfigEntry{
+        "kafkaBroker": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
+        "kafkaTopic": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
+        "kafkaCACert": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
+        "kafkaClientCert": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
+        "kafkaClientKey": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
+        "kafkaSkipVerify": {
+                Set:     configSet,
+                Get:     configGet,
+                Default: "",
+        },
 }
 
-func NewKafkaMessageBusFromConn(conn *kafka.Conn, topic string) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.conns = map[string]*kafka.Conn{topic: conn}
-        ret.topicConnMu = sync.RWMutex{}
-        ret.ctx = context.Background()
-        intRet := messagebus.Messagebus(ret)
-        return intRet, nil
+func configSet(name string, value interface{}) error {
+        configStringsMu.Lock()
+        defer configStringsMu.Unlock()
+
+        switch name {
+        case "kafkaBroker", "kafkaTopic", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
+                configStrings[name] = value.(string)
+        default:
+                return fmt.Errorf("unknown property %s", name)
+        }
+        return nil
 }
 
-func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
-        topic := strings.ReplaceAll(queue, "/", "_")
-        m.topicConnMu.RLock()
-        kconn, ok := m.conns[topic]
-        m.topicConnMu.RUnlock()
-        if !ok || kconn == nil {
-                conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
-
-                // ✅ Log which broker we connected to for this topic
-                log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
-
-                m.topicConnMu.Lock()
-                m.conns[topic] = conn
-                m.topicConnMu.Unlock()
-                kconn = conn
+func configGet(name string) (interface{}, error) {
+        switch name {
+        case "kafkaBroker", "kafkaTopic", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
+                configStringsMu.RLock()
+                ret := configStrings[name]
+                configStringsMu.RUnlock()
+                return ret, nil
+        default:
+                return nil, fmt.Errorf("unknown property %s", name)
         }
-        return kconn, nil
 }
 
-func shouldRestartOnErr(err error) bool {
-        if err == nil {
-                return false
+// getEnvSettings grabs environment variables used to configure kafkapump from the running environment.
+func getEnvSettings() {
+        mbHost := os.Getenv("MESSAGEBUS_HOST")
+        if len(mbHost) > 0 {
+                configStrings["mbhost"] = mbHost
         }
-        // EOF or closed/timeout conditions -> restart
-        if err == io.EOF {
-                return true
+        mbPort := os.Getenv("MESSAGEBUS_PORT")
+        if len(mbPort) > 0 {
+                configStrings["mbport"] = mbPort
         }
-        if ne, ok := err.(net.Error); ok && ne.Timeout() {
-                return true
+        kafkaBroker := os.Getenv("KAFKA_BROKER")
+        if len(kafkaBroker) > 0 {
+                configStrings["kafkaBroker"] = kafkaBroker
         }
-        s := strings.ToLower(err.Error())
-        if strings.Contains(s, "use of closed network connection") ||
-                strings.Contains(s, "broken pipe") ||
-                strings.Contains(s, "connection reset by peer") ||
-                strings.Contains(s, "i/o timeout") {
-                return true
+        kafkaTopic := os.Getenv("KAFKA_TOPIC")
+        if len(kafkaTopic) > 0 {
+                configStrings["kafkaTopic"] = kafkaTopic
         }
-        return false
+        kafkaCert := os.Getenv("KAFKA_CACERT")
+        if len(kafkaCert) > 0 {
+                configStrings["kafkaCACert"] = kafkaCert
+        }
+        kafkaClientCert := os.Getenv("KAFKA_CLIENT_CERT")
+        if len(kafkaClientCert) > 0 {
+                configStrings["kafkaClientCert"] = kafkaClientCert
+        }
+        kafkaClientKey := os.Getenv("KAFKA_CLIENT_KEY")
+        if len(kafkaClientKey) > 0 {
+                configStrings["kafkaClientKey"] = kafkaClientKey
+        }
+        kafkaSkipVerify := os.Getenv("KAFKA_SKIP_VERIFY")
+        if len(kafkaSkipVerify) > 0 {
+                configStrings["kafkaSkipVerify"] = kafkaSkipVerify
+        }
 }
 
-func (m *KafkaMessagebus) SendMessage(message []byte, queue string) error {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
-        return err
-}
 
-func (m *KafkaMessagebus) SendMessageWithHeaders(message []byte, queue string, headers map[string]string) error {
-        var hdrs []kafka.Header
-        for key, value := range headers {
-                hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
-        }
-
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
-
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
-        return err
-}
-
-func (m *KafkaMessagebus) ReceiveMessage(message chan<- string, queue string) (messagebus.Subscription, error) {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return nil, err
-        }
-        go m.RecieveLoop(kconn, message, queue)
-
-        mySub := new(KafkaSubscription)
-        return messagebus.Subscription(mySub), nil
-}
-
-func (m *KafkaMessagebus) RecieveLoop(conn *kafka.Conn, message chan<- string, queue string) {
-        defer func() {
-                _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
-                conn.Close()
-                cancel()
-        }()
-
+func handleGroups(groupsChan chan *databus.DataGroup, kafkamb messagebus.Messagebus) {
         for {
-                // Receive next message
-                msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
-                if err != nil {
-                        log.Println("failed to read message:", err)
-                        // Treat read errors as fatal so the pod is restarted
-                        if shouldRestartOnErr(err) {
-                                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
-                                os.Exit(1)
+                group := <-groupsChan
+                events := make([]*kafkaEvent, len(group.Values))
+
+                for index, value := range group.Values {
+                        // --- timestamp parsing ---
+                        timestamp, err := time.Parse(time.RFC3339, value.Timestamp)
+                        if err != nil {
+                                value.Timestamp = strings.ReplaceAll(value.Timestamp, "+0000", "Z")
+                                timestamp, err = time.Parse(time.RFC3339, value.Timestamp)
+                                if err != nil {
+                                        log.Printf("Error parsing timestamp for point %s: (%s) %v",
+                                                value.Context+"_"+value.ID, value.Timestamp, err)
+                                        continue
+                                }
                         }
+
+                        // --- build event ---
+                        event := new(kafkaEvent)
+                        event.Time = timestamp.Unix()
+                        event.Event = "metric"
+                        event.Host = value.System
+
+                        // --- safe numeric/boolean parsing (silent fallback) ---
+                        var floatVal float64
+                        switch strings.ToLower(value.Value) {
+                        case "true":
+                                floatVal = 1.0
+                        case "false":
+                                floatVal = 0.0
+                        default:
+                                f, err := strconv.ParseFloat(value.Value, 64)
+                                if err != nil {
+                                        f = 0.0 // fallback silently, no log
+                                }
+                                floatVal = f
+                        }
+
+                        event.Fields.Value = floatVal
+                        event.Fields.MetricName = value.Context + "_" + value.ID
+
+                        events[index] = event
+                }
+
+                // --- send to kafka ---
+                configStringsMu.RLock()
+                ktopic := configStrings["kafkaTopic"]
+                configStringsMu.RUnlock()
+
+                jsonStr, _ := json.Marshal(events)
+                if err := kafkamb.SendMessage(jsonStr, ktopic); err != nil {
+                        log.Printf("SendMessage error, terminating for restart: %v", err)
+                        os.Exit(1) // let K8s restart the pod
+                }
+        }
+}
+
+
+func main() {
+        getEnvSettings()
+        configStringsMu.RLock()
+        host := configStrings["mbhost"]
+        port, _ := strconv.Atoi(configStrings["mbport"])
+        configStringsMu.RUnlock()
+
+        // internal message bus
+        var mb messagebus.Messagebus
+        for {
+                smb, err := stomp.NewStompMessageBus(host, port)
+                if err == nil {
+                        defer smb.Close()
+                        mb = smb
                         break
                 }
-                message <- string(msg.Value)
+                log.Printf("Could not connect to message bus (%s:%d): %v ", host, port, err)
+                time.Sleep(time.Minute)
         }
-}
 
-func (m *KafkaMessagebus) Close() error {
-        var err error
-        m.topicConnMu.Lock()
-        defer m.topicConnMu.Unlock()
-        for topic, conn := range m.conns {
-                err1 := conn.Close()
-                if err1 != nil {
-                        err = err1
+        dbClient := new(databus.DataBusClient)
+        dbClient.Bus = mb
+        configService := config.NewConfigService(mb, "/kafkapump/config", configItems)
+
+        dbClient.Subscribe("/kafka")
+        dbClient.Get("/kafka")
+        groupsIn := make(chan *databus.DataGroup, 10)
+        go dbClient.GetGroup(groupsIn, "/kafka")
+        go configService.Run()
+
+        // external message bus - kafka
+        var kafkamb messagebus.Messagebus
+        var ktopic, kcert, kccert, kckey string
+        var kbroker []string
+        var skipVerify bool
+
+        // wait for configuration
+        for {
+                configStringsMu.RLock()
+                kbroker = strings.Split(configStrings["kafkaBroker"], ":")
+                if configStrings["kafkaCACert"] != "" {
+                        kcert = "/extrabin/certs/" + configStrings["kafkaCACert"]
                 }
-                delete(m.conns, topic)
-        }
-        return err
-}
+                if configStrings["kafkaClientCert"] != "" {
+                        kccert = "/extrabin/certs/" + configStrings["kafkaClientCert"]
+                }
+                if configStrings["kafkaClientKey"] != "" {
+                        kckey = "/extrabin/certs/" + configStrings["kafkaClientKey"]
+                }
+                ktopic = configStrings["kafkaTopic"]
 
-func (m *KafkaSubscription) Close() error {
-        return nil
+                if configStrings["kafkaSkipVerify"] == "true" {
+                        skipVerify = true
+                }
+
+                log.Println("configStrings : ", configStrings)
+                configStringsMu.RUnlock()
+
+                // minimum config available
+                if len(kbroker) > 1 && kbroker[0] != "" && ktopic != "" {
+                        log.Printf("Kafka minimum configuration available, continuing ... \n")
+                        break
+                }
+                // wait for min configuration
+                time.Sleep(time.Minute)
+        }
+
+        // connection loop
+        for {
+                tlsCfg := &kafka.KafkaTLSConfig{
+                        ServerCA:   kcert,
+                        ClientCert: kccert,
+                        ClientKey:  kckey,
+                        SkipVerify: skipVerify,
+                }
+
+                khost := kbroker[0]
+                kport, _ := strconv.Atoi(kbroker[1])
+                log.Printf("Connecting to kafka broker (%s:%d) cert file %s\n", khost, kport, kcert)
+
+                kmb, err := kafka.NewKafkaMessageBus(khost, kport, ktopic, tlsCfg)
+                if err == nil {
+                        defer kmb.Close()
+                        kafkamb = kmb
+                        break
+                }
+
+                log.Printf("Could not connect to kafka broker (%s:%d): %v ", khost, kport, err)
+                time.Sleep(time.Minute)
+        }
+
+        log.Printf("Entering processing loop")
+        handleGroups(groupsIn, kafkamb)
 }

--- a/cmd/kafkapump/kafkapump.go
+++ b/cmd/kafkapump/kafkapump.go
@@ -197,12 +197,10 @@ func handleGroups(groupsChan chan *databus.DataGroup, kafkamb messagebus.Message
 
 			events[index] = event
 		}
-
-		// --- send to kafka ---
+		// send
 		configStringsMu.RLock()
 		ktopic := configStrings["kafkaTopic"]
 		configStringsMu.RUnlock()
-
 		jsonStr, _ := json.Marshal(events)
 		if err := kafkamb.SendMessage(jsonStr, ktopic); err != nil {
 			log.Printf("SendMessage error, terminating for restart: %v", err)

--- a/cmd/kafkapump/kafkapump.go
+++ b/cmd/kafkapump/kafkapump.go
@@ -151,8 +151,10 @@ func getEnvSettings() {
 	if len(kafkaSkipVerify) > 0 {
 		configStrings["kafkaSkipVerify"] = kafkaSkipVerify
 	}
+
 }
 
+// handleGroups brings in the events from ActiveMQ
 func handleGroups(groupsChan chan *databus.DataGroup, kafkamb messagebus.Messagebus) {
 	for {
 		group := <-groupsChan // If you are new to GoLang see https://golangdocs.com/channels-in-golang
@@ -170,8 +172,6 @@ func handleGroups(groupsChan chan *databus.DataGroup, kafkamb messagebus.Message
 					continue
 				}
 			}
-
-			// --- build event ---
 			event := new(kafkaEvent)
 			event.Time = timestamp.Unix()
 			event.Event = "metric"
@@ -244,6 +244,7 @@ func main() {
 	// external message bus - kafka
 	var kafkamb messagebus.Messagebus
 	var ktopic, kpart, kcert, kccert, kckey string
+
 	var kbroker []string
 	var skipVerify bool
 
@@ -268,6 +269,7 @@ func main() {
 		}
 
 		log.Println("configStrings : ", configStrings)
+
 		configStringsMu.RUnlock()
 
 		// minimum config available
@@ -290,9 +292,7 @@ func main() {
 
 		khost := kbroker[0]
 		kport, _ := strconv.Atoi(kbroker[1])
-
 		log.Printf("Connecting to kafka broker (%s:%d) with topic %s, partition %s\n", khost, kport, ktopic, kpart)
-
 		p, _ := strconv.Atoi(kpart)
 		kmb, err := kafka.NewKafkaMessageBus(khost, kport, ktopic, p, tlsCfg)
 		if err == nil {
@@ -306,5 +306,6 @@ func main() {
 	}
 
 	log.Printf("Entering processing loop")
+
 	handleGroups(groupsIn, kafkamb)
 }

--- a/cmd/kafkapump/kafkapump.go
+++ b/cmd/kafkapump/kafkapump.go
@@ -1,292 +1,303 @@
 package main
 
 import (
-        "encoding/json"
-        "fmt"
-        "log"
-        "os"
-        "strconv"
-        "strings"
-        "sync"
-        "time"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/config"
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/databus"
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/kafka"
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/stomp"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/config"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/databus"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/kafka"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus/stomp"
 )
 
 type kafkaEventFields struct {
-        Value      float64 `json:"_value"`
-        MetricName string  `json:"metric_name"`
-        Source     string  `json:"source"`
+	Value      float64 `json:"_value"`
+	MetricName string  `json:"metric_name"`
+	Source     string  `json:"source"`
 }
 
 type kafkaEvent struct {
-        Time   int64            `json:"time"`
-        Event  string           `json:"event"`
-        Host   string           `json:"host"`
-        Fields kafkaEventFields `json:"fields"`
+	Time   int64            `json:"time"`
+	Event  string           `json:"event"`
+	Host   string           `json:"host"`
+	Fields kafkaEventFields `json:"fields"`
 }
 
 var configStringsMu sync.RWMutex
 var configStrings = map[string]string{
-        "mbhost":          "activemq",
-        "mbport":          "61613",
-        "kafkaBroker":     "",
-        "kafkaTopic":      "",
-        "kafkaCACert":     "",
-        "kafkaClientCert": "",
-        "kafkaClientKey":  "",
-        "kafkaSkipVerify": "",
+	"mbhost":          "activemq",
+	"mbport":          "61613",
+	"kafkaBroker":     "",
+	"kafkaTopic":      "",
+	"kafkaPartition":  "0",
+	"kafkaCACert":     "",
+	"kafkaClientCert": "",
+	"kafkaClientKey":  "",
+	"kafkaSkipVerify": "",
 }
 
 var configItems = map[string]*config.ConfigEntry{
-        "kafkaBroker": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
-        "kafkaTopic": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
-        "kafkaCACert": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
-        "kafkaClientCert": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
-        "kafkaClientKey": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
-        "kafkaSkipVerify": {
-                Set:     configSet,
-                Get:     configGet,
-                Default: "",
-        },
+	"kafkaBroker": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
+	"kafkaTopic": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
+	"kafkaPartition": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "0",
+	},
+	"kafkaCACert": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
+	"kafkaClientCert": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
+	"kafkaClientKey": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
+	"kafkaSkipVerify": {
+		Set:     configSet,
+		Get:     configGet,
+		Default: "",
+	},
 }
 
 func configSet(name string, value interface{}) error {
-        configStringsMu.Lock()
-        defer configStringsMu.Unlock()
+	configStringsMu.Lock()
+	defer configStringsMu.Unlock()
 
-        switch name {
-        case "kafkaBroker", "kafkaTopic", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
-                configStrings[name] = value.(string)
-        default:
-                return fmt.Errorf("unknown property %s", name)
-        }
-        return nil
+	switch name {
+	case "kafkaBroker", "kafkaTopic", "kafkaPartition", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
+		configStrings[name] = value.(string)
+	default:
+		return fmt.Errorf("unknown property %s", name)
+	}
+	return nil
 }
 
 func configGet(name string) (interface{}, error) {
-        switch name {
-        case "kafkaBroker", "kafkaTopic", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
-                configStringsMu.RLock()
-                ret := configStrings[name]
-                configStringsMu.RUnlock()
-                return ret, nil
-        default:
-                return nil, fmt.Errorf("unknown property %s", name)
-        }
+	switch name {
+	case "kafkaBroker", "kafkaTopic", "kafkaPartition", "kafkaCACert", "kafkaClientCert", "kafkaClientKey", "kafkaSkipVerify":
+		configStringsMu.RLock()
+		ret := configStrings[name]
+		configStringsMu.RUnlock()
+		return ret, nil
+	default:
+		return nil, fmt.Errorf("unknown property %s", name)
+	}
 }
 
 // getEnvSettings grabs environment variables used to configure kafkapump from the running environment.
 func getEnvSettings() {
-        mbHost := os.Getenv("MESSAGEBUS_HOST")
-        if len(mbHost) > 0 {
-                configStrings["mbhost"] = mbHost
-        }
-        mbPort := os.Getenv("MESSAGEBUS_PORT")
-        if len(mbPort) > 0 {
-                configStrings["mbport"] = mbPort
-        }
-        kafkaBroker := os.Getenv("KAFKA_BROKER")
-        if len(kafkaBroker) > 0 {
-                configStrings["kafkaBroker"] = kafkaBroker
-        }
-        kafkaTopic := os.Getenv("KAFKA_TOPIC")
-        if len(kafkaTopic) > 0 {
-                configStrings["kafkaTopic"] = kafkaTopic
-        }
-        kafkaCert := os.Getenv("KAFKA_CACERT")
-        if len(kafkaCert) > 0 {
-                configStrings["kafkaCACert"] = kafkaCert
-        }
-        kafkaClientCert := os.Getenv("KAFKA_CLIENT_CERT")
-        if len(kafkaClientCert) > 0 {
-                configStrings["kafkaClientCert"] = kafkaClientCert
-        }
-        kafkaClientKey := os.Getenv("KAFKA_CLIENT_KEY")
-        if len(kafkaClientKey) > 0 {
-                configStrings["kafkaClientKey"] = kafkaClientKey
-        }
-        kafkaSkipVerify := os.Getenv("KAFKA_SKIP_VERIFY")
-        if len(kafkaSkipVerify) > 0 {
-                configStrings["kafkaSkipVerify"] = kafkaSkipVerify
-        }
+	mbHost := os.Getenv("MESSAGEBUS_HOST")
+	if len(mbHost) > 0 {
+		configStrings["mbhost"] = mbHost
+	}
+	mbPort := os.Getenv("MESSAGEBUS_PORT")
+	if len(mbPort) > 0 {
+		configStrings["mbport"] = mbPort
+	}
+	kafkaBroker := os.Getenv("KAFKA_BROKER")
+	if len(kafkaBroker) > 0 {
+		configStrings["kafkaBroker"] = kafkaBroker
+	}
+	kafkaTopic := os.Getenv("KAFKA_TOPIC")
+	if len(kafkaTopic) > 0 {
+		configStrings["kafkaTopic"] = kafkaTopic
+	}
+	kafkaPartition := os.Getenv("KAFKA_PARTITION")
+	if len(kafkaPartition) > 0 {
+		configStrings["kafkaPartition"] = kafkaPartition
+	}
+	kafkaCert := os.Getenv("KAFKA_CACERT")
+	if len(kafkaCert) > 0 {
+		configStrings["kafkaCACert"] = kafkaCert
+	}
+	kafkaClientCert := os.Getenv("KAFKA_CLIENT_CERT")
+	if len(kafkaClientCert) > 0 {
+		configStrings["kafkaClientCert"] = kafkaClientCert
+	}
+	kafkaClientKey := os.Getenv("KAFKA_CLIENT_KEY")
+	if len(kafkaClientKey) > 0 {
+		configStrings["kafkaClientKey"] = kafkaClientKey
+	}
+	kafkaSkipVerify := os.Getenv("KAFKA_SKIP_VERIFY")
+	if len(kafkaSkipVerify) > 0 {
+		configStrings["kafkaSkipVerify"] = kafkaSkipVerify
+	}
 }
-
 
 func handleGroups(groupsChan chan *databus.DataGroup, kafkamb messagebus.Messagebus) {
-        for {
-                group := <-groupsChan
-                events := make([]*kafkaEvent, len(group.Values))
+	for {
+		group := <-groupsChan
+		events := make([]*kafkaEvent, len(group.Values))
 
-                for index, value := range group.Values {
-                        // --- timestamp parsing ---
-                        timestamp, err := time.Parse(time.RFC3339, value.Timestamp)
-                        if err != nil {
-                                value.Timestamp = strings.ReplaceAll(value.Timestamp, "+0000", "Z")
-                                timestamp, err = time.Parse(time.RFC3339, value.Timestamp)
-                                if err != nil {
-                                        log.Printf("Error parsing timestamp for point %s: (%s) %v",
-                                                value.Context+"_"+value.ID, value.Timestamp, err)
-                                        continue
-                                }
-                        }
+		for index, value := range group.Values {
+			// --- timestamp parsing ---
+			timestamp, err := time.Parse(time.RFC3339, value.Timestamp)
+			if err != nil {
+				value.Timestamp = strings.ReplaceAll(value.Timestamp, "+0000", "Z")
+				timestamp, err = time.Parse(time.RFC3339, value.Timestamp)
+				if err != nil {
+					log.Printf("Error parsing timestamp for point %s: (%s) %v",
+						value.Context+"_"+value.ID, value.Timestamp, err)
+					continue
+				}
+			}
 
-                        // --- build event ---
-                        event := new(kafkaEvent)
-                        event.Time = timestamp.Unix()
-                        event.Event = "metric"
-                        event.Host = value.System
+			// --- build event ---
+			event := new(kafkaEvent)
+			event.Time = timestamp.Unix()
+			event.Event = "metric"
+			event.Host = value.System
 
-                        // --- safe numeric/boolean parsing (silent fallback) ---
-                        var floatVal float64
-                        switch strings.ToLower(value.Value) {
-                        case "true":
-                                floatVal = 1.0
-                        case "false":
-                                floatVal = 0.0
-                        default:
-                                f, err := strconv.ParseFloat(value.Value, 64)
-                                if err != nil {
-                                        f = 0.0 // fallback silently, no log
-                                }
-                                floatVal = f
-                        }
+			// --- safe numeric/boolean parsing (silent fallback) ---
+			var floatVal float64
+			switch strings.ToLower(value.Value) {
+			case "true":
+				floatVal = 1.0
+			case "false":
+				floatVal = 0.0
+			default:
+				f, err := strconv.ParseFloat(value.Value, 64)
+				if err != nil {
+					f = 0.0 // fallback silently, no log
+				}
+				floatVal = f
+			}
 
-                        event.Fields.Value = floatVal
-                        event.Fields.MetricName = value.Context + "_" + value.ID
+			event.Fields.Value = floatVal
+			event.Fields.MetricName = value.Context + "_" + value.ID
 
-                        events[index] = event
-                }
+			events[index] = event
+		}
 
-                // --- send to kafka ---
-                configStringsMu.RLock()
-                ktopic := configStrings["kafkaTopic"]
-                configStringsMu.RUnlock()
+		// --- send to kafka ---
+		configStringsMu.RLock()
+		ktopic := configStrings["kafkaTopic"]
+		configStringsMu.RUnlock()
 
-                jsonStr, _ := json.Marshal(events)
-                if err := kafkamb.SendMessage(jsonStr, ktopic); err != nil {
-                        log.Printf("SendMessage error, terminating for restart: %v", err)
-                        os.Exit(1) // let K8s restart the pod
-                }
-        }
+		jsonStr, _ := json.Marshal(events)
+		if err := kafkamb.SendMessage(jsonStr, ktopic); err != nil {
+			log.Printf("SendMessage error, terminating for restart: %v", err)
+			os.Exit(1) // let K8s restart the pod
+		}
+	}
 }
 
-
 func main() {
-        getEnvSettings()
-        configStringsMu.RLock()
-        host := configStrings["mbhost"]
-        port, _ := strconv.Atoi(configStrings["mbport"])
-        configStringsMu.RUnlock()
+	getEnvSettings()
+	configStringsMu.RLock()
+	host := configStrings["mbhost"]
+	port, _ := strconv.Atoi(configStrings["mbport"])
+	configStringsMu.RUnlock()
 
-        // internal message bus
-        var mb messagebus.Messagebus
-        for {
-                smb, err := stomp.NewStompMessageBus(host, port)
-                if err == nil {
-                        defer smb.Close()
-                        mb = smb
-                        break
-                }
-                log.Printf("Could not connect to message bus (%s:%d): %v ", host, port, err)
-                time.Sleep(time.Minute)
-        }
+	// internal message bus
+	var mb messagebus.Messagebus
+	for {
+		smb, err := stomp.NewStompMessageBus(host, port)
+		if err == nil {
+			defer smb.Close()
+			mb = smb
+			break
+		}
+		log.Printf("Could not connect to message bus (%s:%d): %v ", host, port, err)
+		time.Sleep(time.Minute)
+	}
 
-        dbClient := new(databus.DataBusClient)
-        dbClient.Bus = mb
-        configService := config.NewConfigService(mb, "/kafkapump/config", configItems)
+	dbClient := new(databus.DataBusClient)
+	dbClient.Bus = mb
+	configService := config.NewConfigService(mb, "/kafkapump/config", configItems)
 
-        dbClient.Subscribe("/kafka")
-        dbClient.Get("/kafka")
-        groupsIn := make(chan *databus.DataGroup, 10)
-        go dbClient.GetGroup(groupsIn, "/kafka")
-        go configService.Run()
+	dbClient.Subscribe("/kafka")
+	dbClient.Get("/kafka")
+	groupsIn := make(chan *databus.DataGroup, 10)
+	go dbClient.GetGroup(groupsIn, "/kafka")
+	go configService.Run()
 
-        // external message bus - kafka
-        var kafkamb messagebus.Messagebus
-        var ktopic, kcert, kccert, kckey string
-        var kbroker []string
-        var skipVerify bool
+	// external message bus - kafka
+	var kafkamb messagebus.Messagebus
+	var ktopic, kpart, kcert, kccert, kckey string
+	var kbroker []string
+	var skipVerify bool
 
-        // wait for configuration
-        for {
-                configStringsMu.RLock()
-                kbroker = strings.Split(configStrings["kafkaBroker"], ":")
-                if configStrings["kafkaCACert"] != "" {
-                        kcert = "/extrabin/certs/" + configStrings["kafkaCACert"]
-                }
-                if configStrings["kafkaClientCert"] != "" {
-                        kccert = "/extrabin/certs/" + configStrings["kafkaClientCert"]
-                }
-                if configStrings["kafkaClientKey"] != "" {
-                        kckey = "/extrabin/certs/" + configStrings["kafkaClientKey"]
-                }
-                ktopic = configStrings["kafkaTopic"]
+	// wait for configuration
+	for {
+		configStringsMu.RLock()
+		kbroker = strings.Split(configStrings["kafkaBroker"], ":")
+		if configStrings["kafkaCACert"] != "" {
+			kcert = "/extrabin/certs/" + configStrings["kafkaCACert"]
+		}
+		if configStrings["kafkaClientCert"] != "" {
+			kccert = "/extrabin/certs/" + configStrings["kafkaClientCert"]
+		}
+		if configStrings["kafkaClientKey"] != "" {
+			kckey = "/extrabin/certs/" + configStrings["kafkaClientKey"]
+		}
+		ktopic = configStrings["kafkaTopic"]
+		kpart = configStrings["kafkaPartition"]
 
-                if configStrings["kafkaSkipVerify"] == "true" {
-                        skipVerify = true
-                }
+		if configStrings["kafkaSkipVerify"] == "true" {
+			skipVerify = true
+		}
 
-                log.Println("configStrings : ", configStrings)
-                configStringsMu.RUnlock()
+		log.Println("configStrings : ", configStrings)
+		configStringsMu.RUnlock()
 
-                // minimum config available
-                if len(kbroker) > 1 && kbroker[0] != "" && ktopic != "" {
-                        log.Printf("Kafka minimum configuration available, continuing ... \n")
-                        break
-                }
-                // wait for min configuration
-                time.Sleep(time.Minute)
-        }
+		// minimum config available
+		if len(kbroker) > 1 && kbroker[0] != "" && ktopic != "" {
+			log.Printf("Kafka minimum configuration available, continuing ... \n")
+			break
+		}
+		// wait for min configuration
+		time.Sleep(time.Minute)
+	}
 
-        // connection loop
-        for {
-                tlsCfg := &kafka.KafkaTLSConfig{
-                        ServerCA:   kcert,
-                        ClientCert: kccert,
-                        ClientKey:  kckey,
-                        SkipVerify: skipVerify,
-                }
+	// connection loop
+	for {
+		tlsCfg := &kafka.KafkaTLSConfig{
+			ServerCA:   kcert,
+			ClientCert: kccert,
+			ClientKey:  kckey,
+			SkipVerify: skipVerify,
+		}
 
-                khost := kbroker[0]
-                kport, _ := strconv.Atoi(kbroker[1])
-                log.Printf("Connecting to kafka broker (%s:%d) cert file %s\n", khost, kport, kcert)
+		khost := kbroker[0]
+		kport, _ := strconv.Atoi(kbroker[1])
 
-                kmb, err := kafka.NewKafkaMessageBus(khost, kport, ktopic, tlsCfg)
-                if err == nil {
-                        defer kmb.Close()
-                        kafkamb = kmb
-                        break
-                }
+		log.Printf("Connecting to kafka broker (%s:%d) with topic %s, partition %s\n", khost, kport, ktopic, kpart)
 
-                log.Printf("Could not connect to kafka broker (%s:%d): %v ", khost, kport, err)
-                time.Sleep(time.Minute)
-        }
+		p, _ := strconv.Atoi(kpart)
+		kmb, err := kafka.NewKafkaMessageBus(khost, kport, ktopic, p, tlsCfg)
+		if err == nil {
+			defer kmb.Close()
+			kafkamb = kmb
+			break
+		}
 
-        log.Printf("Entering processing loop")
-        handleGroups(groupsIn, kafkamb)
+		log.Printf("Could not connect to kafka broker (%s:%d): %v ", khost, kport, err)
+		time.Sleep(time.Minute)
+	}
+
+	log.Printf("Entering processing loop")
+	handleGroups(groupsIn, kafkamb)
 }

--- a/internal/messagebus/kafka/kafka.go
+++ b/internal/messagebus/kafka/kafka.go
@@ -96,7 +96,7 @@ func NewKafkaMessageBus(host string, port int, topic string, partition int, tlsC
 			log.Println("kafka.DialLeader: could not connect ", err)
 			return nil, err
 		}
-		// ✅ Log the actual broker & partition we got connected to
+		// Log the actual broker & partition we got connected to
 		log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
 			conn.RemoteAddr().String(), topic, 0)
 
@@ -129,7 +129,7 @@ func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
 			log.Println("kafka.DialLeader: could not connect ", err)
 			return nil, err
 		}
-		// ✅ Log which broker we connected to for this topic
+		// Log which broker we connected to for this topic
 		log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
 			conn.RemoteAddr().String(), topic, 0)
 

--- a/internal/messagebus/kafka/kafka.go
+++ b/internal/messagebus/kafka/kafka.go
@@ -3,257 +3,257 @@
 package kafka
 
 import (
-        "context"
-        "crypto/tls"
-        "crypto/x509"
-        "fmt"
-        "io"
-        "log"
-        "net"
-        "os"
-        "strings"
-        "sync"
-        "time"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
 
-        kafka "github.com/segmentio/kafka-go"
+	kafka "github.com/segmentio/kafka-go"
 
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
 )
 
 const KafkaMaxMessageBytes = 16 * 1024
 
 type KafkaMessagebus struct {
-        conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
-        addr        string
-        ctx         context.Context
-        dialer      *kafka.Dialer
-        topicConnMu sync.RWMutex
+	conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
+	addr        string
+	ctx         context.Context
+	dialer      *kafka.Dialer
+	topicConnMu sync.RWMutex
 }
 
 type KafkaSubscription struct {
 }
 
 type KafkaTLSConfig struct {
-        ServerCA   string
-        ClientCert string
-        ClientKey  string
-        SkipVerify bool // skip hostname check
+	ServerCA   string
+	ClientCert string
+	ClientKey  string
+	SkipVerify bool // skip hostname check
 }
 
-func NewKafkaMessageBus(host string, port int, topic string, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.addr = fmt.Sprintf("%s:%d", host, port)
-        ret.ctx = context.Background()
-        ret.conns = map[string]*kafka.Conn{}
-        ret.topicConnMu = sync.RWMutex{}
+func NewKafkaMessageBus(host string, port int, topic string, partition int, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
+	ret := new(KafkaMessagebus)
+	ret.addr = fmt.Sprintf("%s:%d", host, port)
+	ret.ctx = context.Background()
+	ret.conns = map[string]*kafka.Conn{}
+	ret.topicConnMu = sync.RWMutex{}
 
-        dialer := &kafka.Dialer{
-                Timeout:   10 * time.Second,
-                DualStack: true,
-        }
+	dialer := &kafka.Dialer{
+		Timeout:   10 * time.Second,
+		DualStack: true,
+	}
 
-        // TLS
-        if tlsCfg != nil && tlsCfg.ServerCA != "" {
-                ca, err := os.ReadFile(tlsCfg.ServerCA)
-                if err != nil {
-                        log.Println("failed to load server CA cert", err)
-                        return nil, err
-                }
-                pool := x509.NewCertPool()
-                if ok := pool.AppendCertsFromPEM(ca); !ok {
-                        log.Println("Unable to apppend cert to pool")
-                }
+	// TLS
+	if tlsCfg != nil && tlsCfg.ServerCA != "" {
+		ca, err := os.ReadFile(tlsCfg.ServerCA)
+		if err != nil {
+			log.Println("failed to load server CA cert", err)
+			return nil, err
+		}
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM(ca); !ok {
+			log.Println("Unable to apppend cert to pool")
+		}
 
-                config := tls.Config{
-                        RootCAs:            pool,
-                        MinVersion:         tls.VersionTLS12,
-                        InsecureSkipVerify: tlsCfg.SkipVerify,
-                }
+		config := tls.Config{
+			RootCAs:            pool,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: tlsCfg.SkipVerify,
+		}
 
-                // Client Authentication - optional
-                if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
-                        ccrt, err := os.ReadFile(tlsCfg.ClientCert)
-                        if err != nil {
-                                log.Println("failed to load client cert", err)
-                                return nil, err
-                        }
-                        ckey, err := os.ReadFile(tlsCfg.ClientKey)
-                        if err != nil {
-                                log.Println("failed to load client key", err)
-                                return nil, err
-                        }
-                        cert, err := tls.X509KeyPair(ccrt, ckey)
-                        if err != nil {
-                                log.Println("X509KeyPair error ", err)
-                                return nil, err
-                        }
-                        config.Certificates = []tls.Certificate{cert}
-                }
-                dialer.TLS = &config
-        }
+		// Client Authentication - optional
+		if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
+			ccrt, err := os.ReadFile(tlsCfg.ClientCert)
+			if err != nil {
+				log.Println("failed to load client cert", err)
+				return nil, err
+			}
+			ckey, err := os.ReadFile(tlsCfg.ClientKey)
+			if err != nil {
+				log.Println("failed to load client key", err)
+				return nil, err
+			}
+			cert, err := tls.X509KeyPair(ccrt, ckey)
+			if err != nil {
+				log.Println("X509KeyPair error ", err)
+				return nil, err
+			}
+			config.Certificates = []tls.Certificate{cert}
+		}
+		dialer.TLS = &config
+	}
 
-        ret.dialer = dialer
-        if topic != "" {
-                conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
+	ret.dialer = dialer
+	if topic != "" {
+		conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, partition)
+		if err != nil || conn == nil {
+			log.Println("kafka.DialLeader: could not connect ", err)
+			return nil, err
+		}
 
-                // ✅ Log the actual broker & partition we got connected to
-                log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
+		// ✅ Log the actual broker & partition we got connected to
+		log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
+			conn.RemoteAddr().String(), topic, partition)
 
-                ret.topicConnMu.Lock()
-                ret.conns[topic] = conn
-                ret.topicConnMu.Unlock()
-        }
+		ret.topicConnMu.Lock()
+		ret.conns[topic] = conn
+		ret.topicConnMu.Unlock()
+	}
 
-        return messagebus.Messagebus(ret), nil
+	return messagebus.Messagebus(ret), nil
 }
 
 func NewKafkaMessageBusFromConn(conn *kafka.Conn, topic string) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.conns = map[string]*kafka.Conn{topic: conn}
-        ret.topicConnMu = sync.RWMutex{}
-        ret.ctx = context.Background()
-        intRet := messagebus.Messagebus(ret)
-        return intRet, nil
+	ret := new(KafkaMessagebus)
+	ret.conns = map[string]*kafka.Conn{topic: conn}
+	ret.topicConnMu = sync.RWMutex{}
+	ret.ctx = context.Background()
+	intRet := messagebus.Messagebus(ret)
+	return intRet, nil
 }
 
 func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
-        topic := strings.ReplaceAll(queue, "/", "_")
-        m.topicConnMu.RLock()
-        kconn, ok := m.conns[topic]
-        m.topicConnMu.RUnlock()
-        if !ok || kconn == nil {
-                conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
+	topic := strings.ReplaceAll(queue, "/", "_")
+	m.topicConnMu.RLock()
+	kconn, ok := m.conns[topic]
+	m.topicConnMu.RUnlock()
+	if !ok || kconn == nil {
+		conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
+		if err != nil || conn == nil {
+			log.Println("kafka.DialLeader: could not connect ", err)
+			return nil, err
+		}
 
-                // ✅ Log which broker we connected to for this topic
-                log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
+		// ✅ Log which broker we connected to for this topic
+		log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
+			conn.RemoteAddr().String(), topic, 0)
 
-                m.topicConnMu.Lock()
-                m.conns[topic] = conn
-                m.topicConnMu.Unlock()
-                kconn = conn
-        }
-        return kconn, nil
+		m.topicConnMu.Lock()
+		m.conns[topic] = conn
+		m.topicConnMu.Unlock()
+		kconn = conn
+	}
+	return kconn, nil
 }
 
 func shouldRestartOnErr(err error) bool {
-        if err == nil {
-                return false
-        }
-        // EOF or closed/timeout conditions -> restart
-        if err == io.EOF {
-                return true
-        }
-        if ne, ok := err.(net.Error); ok && ne.Timeout() {
-                return true
-        }
-        s := strings.ToLower(err.Error())
-        if strings.Contains(s, "use of closed network connection") ||
-                strings.Contains(s, "broken pipe") ||
-                strings.Contains(s, "connection reset by peer") ||
-                strings.Contains(s, "i/o timeout") {
-                return true
-        }
-        return false
+	if err == nil {
+		return false
+	}
+	// EOF or closed/timeout conditions -> restart
+	if err == io.EOF {
+		return true
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "use of closed network connection") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "connection reset by peer") ||
+		strings.Contains(s, "i/o timeout") {
+		return true
+	}
+	return false
 }
 
 func (m *KafkaMessagebus) SendMessage(message []byte, queue string) error {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
-        return err
+	kconn, err := m.TopicConnect(queue)
+	if err != nil || kconn == nil {
+		return err
+	}
+	kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_, err = kconn.WriteMessages(kafka.Message{Value: message})
+	if err != nil {
+		log.Println("failed to write messages:", queue, err)
+		if shouldRestartOnErr(err) {
+			log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
+			os.Exit(1)
+		}
+	}
+	return err
 }
 
 func (m *KafkaMessagebus) SendMessageWithHeaders(message []byte, queue string, headers map[string]string) error {
-        var hdrs []kafka.Header
-        for key, value := range headers {
-                hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
-        }
+	var hdrs []kafka.Header
+	for key, value := range headers {
+		hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
+	}
 
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
+	kconn, err := m.TopicConnect(queue)
+	if err != nil || kconn == nil {
+		return err
+	}
 
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
-        return err
+	kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	_, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
+	if err != nil {
+		log.Println("failed to write messages:", queue, err)
+		if shouldRestartOnErr(err) {
+			log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
+			os.Exit(1)
+		}
+	}
+	return err
 }
 
 func (m *KafkaMessagebus) ReceiveMessage(message chan<- string, queue string) (messagebus.Subscription, error) {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return nil, err
-        }
-        go m.RecieveLoop(kconn, message, queue)
+	kconn, err := m.TopicConnect(queue)
+	if err != nil || kconn == nil {
+		return nil, err
+	}
+	go m.RecieveLoop(kconn, message, queue)
 
-        mySub := new(KafkaSubscription)
-        return messagebus.Subscription(mySub), nil
+	mySub := new(KafkaSubscription)
+	return messagebus.Subscription(mySub), nil
 }
 
 func (m *KafkaMessagebus) RecieveLoop(conn *kafka.Conn, message chan<- string, queue string) {
-        defer func() {
-                _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
-                conn.Close()
-                cancel()
-        }()
+	defer func() {
+		_, cancel := context.WithTimeout(m.ctx, 1*time.Second)
+		conn.Close()
+		cancel()
+	}()
 
-        for {
-                // Receive next message
-                msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
-                if err != nil {
-                        log.Println("failed to read message:", err)
-                        // Treat read errors as fatal so the pod is restarted
-                        if shouldRestartOnErr(err) {
-                                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
-                                os.Exit(1)
-                        }
-                        break
-                }
-                message <- string(msg.Value)
-        }
+	for {
+		// Receive next message
+		msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
+		if err != nil {
+			log.Println("failed to read message:", err)
+			// Treat read errors as fatal so the pod is restarted
+			if shouldRestartOnErr(err) {
+				log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
+				os.Exit(1)
+			}
+			break
+		}
+		message <- string(msg.Value)
+	}
 }
 
 func (m *KafkaMessagebus) Close() error {
-        var err error
-        m.topicConnMu.Lock()
-        defer m.topicConnMu.Unlock()
-        for topic, conn := range m.conns {
-                err1 := conn.Close()
-                if err1 != nil {
-                        err = err1
-                }
-                delete(m.conns, topic)
-        }
-        return err
+	var err error
+	m.topicConnMu.Lock()
+	defer m.topicConnMu.Unlock()
+	for topic, conn := range m.conns {
+		err1 := conn.Close()
+		if err1 != nil {
+			err = err1
+		}
+		delete(m.conns, topic)
+	}
+	return err
 }
 
 func (m *KafkaSubscription) Close() error {
-        return nil
+	return nil
 }

--- a/internal/messagebus/kafka/kafka.go
+++ b/internal/messagebus/kafka/kafka.go
@@ -3,257 +3,247 @@
 package kafka
 
 import (
-        "context"
-        "crypto/tls"
-        "crypto/x509"
-        "fmt"
-        "io"
-        "log"
-        "net"
-        "os"
-        "strings"
-        "sync"
-        "time"
+    "context"
+    "crypto/tls"
+    "crypto/x509"
+    "fmt"
+    "io"
+    "log"
+    "net"
+    "os"
+    "strings"
+    "sync"
+    "time"
 
-        kafka "github.com/segmentio/kafka-go"
+    kafka "github.com/segmentio/kafka-go"
 
-        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+    "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
 )
 
 const KafkaMaxMessageBytes = 16 * 1024
 
 type KafkaMessagebus struct {
-        conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
-        addr        string
-        ctx         context.Context
-        dialer      *kafka.Dialer
-        topicConnMu sync.RWMutex
+    conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
+    addr        string
+    ctx         context.Context
+    dialer      *kafka.Dialer
+    topicConnMu sync.RWMutex
 }
 
 type KafkaSubscription struct {
 }
 
 type KafkaTLSConfig struct {
-        ServerCA   string
-        ClientCert string
-        ClientKey  string
-        SkipVerify bool // skip hostname check
+    ServerCA   string
+    ClientCert string
+    ClientKey  string
+    SkipVerify bool // skip hostname check
 }
 
 func NewKafkaMessageBus(host string, port int, topic string, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.addr = fmt.Sprintf("%s:%d", host, port)
-        ret.ctx = context.Background()
-        ret.conns = map[string]*kafka.Conn{}
-        ret.topicConnMu = sync.RWMutex{}
+    ret := new(KafkaMessagebus)
+    ret.addr = fmt.Sprintf("%s:%d", host, port)
+    ret.ctx = context.Background()
+    ret.conns = map[string]*kafka.Conn{}
+    ret.topicConnMu = sync.RWMutex{}
 
-        dialer := &kafka.Dialer{
-                Timeout:   10 * time.Second,
-                DualStack: true,
+    dialer := &kafka.Dialer{
+        Timeout:   10 * time.Second,
+        DualStack: true,
+    }
+
+    // TLS
+    if tlsCfg != nil && tlsCfg.ServerCA != "" {
+        ca, err := os.ReadFile(tlsCfg.ServerCA)
+        if err != nil {
+            log.Println("failed to load server CA cert", err)
+            return nil, err
+        }
+        pool := x509.NewCertPool()
+        if ok := pool.AppendCertsFromPEM(ca); !ok {
+            log.Println("Unable to apppend cert to pool")
         }
 
-        // TLS
-        if tlsCfg != nil && tlsCfg.ServerCA != "" {
-                ca, err := os.ReadFile(tlsCfg.ServerCA)
-                if err != nil {
-                        log.Println("failed to load server CA cert", err)
-                        return nil, err
-                }
-                pool := x509.NewCertPool()
-                if ok := pool.AppendCertsFromPEM(ca); !ok {
-                        log.Println("Unable to apppend cert to pool")
-                }
-
-                config := tls.Config{
-                        RootCAs:            pool,
-                        MinVersion:         tls.VersionTLS12,
-                        InsecureSkipVerify: tlsCfg.SkipVerify,
-                }
-
-                // Client Authentication - optional
-                if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
-                        ccrt, err := os.ReadFile(tlsCfg.ClientCert)
-                        if err != nil {
-                                log.Println("failed to load client cert", err)
-                                return nil, err
-                        }
-                        ckey, err := os.ReadFile(tlsCfg.ClientKey)
-                        if err != nil {
-                                log.Println("failed to load client key", err)
-                                return nil, err
-                        }
-                        cert, err := tls.X509KeyPair(ccrt, ckey)
-                        if err != nil {
-                                log.Println("X509KeyPair error ", err)
-                                return nil, err
-                        }
-                        config.Certificates = []tls.Certificate{cert}
-                }
-                dialer.TLS = &config
+        config := tls.Config{
+            RootCAs:            pool,
+            MinVersion:         tls.VersionTLS12,
+            InsecureSkipVerify: tlsCfg.SkipVerify,
         }
 
-        ret.dialer = dialer
-        if topic != "" {
-                conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
+        // Client Authentication - optional
+        if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
+            ccrt, err := os.ReadFile(tlsCfg.ClientCert)
+            if err != nil {
+                log.Println("failed to load client cert", err)
+                return nil, err
+            }
+            ckey, err := os.ReadFile(tlsCfg.ClientKey)
+            if err != nil {
+                log.Println("failed to load client key", err)
+                return nil, err
+            }
+            cert, err := tls.X509KeyPair(ccrt, ckey)
+            if err != nil {
+                log.Println("X509KeyPair error ", err)
+                return nil, err
+            }
+            config.Certificates = []tls.Certificate{cert}
+        }
+        dialer.TLS = &config
+    }
 
-                // ✅ Log the actual broker & partition we got connected to
-                log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
-
-                ret.topicConnMu.Lock()
-                ret.conns[topic] = conn
-                ret.topicConnMu.Unlock()
+    ret.dialer = dialer
+    if topic != "" {
+        conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
+        if err != nil || conn == nil {
+            log.Println("kafka.DialLeader: could not connect ", err)
+            return nil, err
         }
 
-        return messagebus.Messagebus(ret), nil
+        // ✅ Log the actual broker & partition we got connected to
+        log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
+            conn.RemoteAddr().String(), topic, 0)
+
+        ret.topicConnMu.Lock()
+        ret.conns[topic] = conn
+        ret.topicConnMu.Unlock()
+    }
+
+    return messagebus.Messagebus(ret), nil
 }
 
 func NewKafkaMessageBusFromConn(conn *kafka.Conn, topic string) (messagebus.Messagebus, error) {
-        ret := new(KafkaMessagebus)
-        ret.conns = map[string]*kafka.Conn{topic: conn}
-        ret.topicConnMu = sync.RWMutex{}
-        ret.ctx = context.Background()
-        intRet := messagebus.Messagebus(ret)
-        return intRet, nil
+    ret := new(KafkaMessagebus)
+    ret.conns = map[string]*kafka.Conn{topic: conn}
+    ret.topicConnMu = sync.RWMutex{}
+    ret.ctx = context.Background()
+    intRet := messagebus.Messagebus(ret)
+    return intRet, nil
 }
 
 func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
-        topic := strings.ReplaceAll(queue, "/", "_")
-        m.topicConnMu.RLock()
-        kconn, ok := m.conns[topic]
-        m.topicConnMu.RUnlock()
-        if !ok || kconn == nil {
-                conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
-                if err != nil || conn == nil {
-                        log.Println("kafka.DialLeader: could not connect ", err)
-                        return nil, err
-                }
-
-                // ✅ Log which broker we connected to for this topic
-                log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
-                        conn.RemoteAddr().String(), topic, 0)
-
-                m.topicConnMu.Lock()
-                m.conns[topic] = conn
-                m.topicConnMu.Unlock()
-                kconn = conn
+    topic := strings.ReplaceAll(queue, "/", "_")
+    m.topicConnMu.RLock()
+    kconn, ok := m.conns[topic]
+    m.topicConnMu.RUnlock()
+    if !ok || kconn == nil {
+        conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
+        if err != nil || conn == nil {
+            log.Println("kafka.DialLeader: could not connect ", err)
+            return nil, err
         }
-        return kconn, nil
+
+        // ✅ Log which broker we connected to for this topic
+        log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
+            conn.RemoteAddr().String(), topic, 0)
+
+        m.topicConnMu.Lock()
+        m.conns[topic] = conn
+        m.topicConnMu.Unlock()
+        kconn = conn
+    }
+    return kconn, nil
 }
 
 func shouldRestartOnErr(err error) bool {
-        if err == nil {
-                return false
-        }
-        // EOF or closed/timeout conditions -> restart
-        if err == io.EOF {
-                return true
-        }
-        if ne, ok := err.(net.Error); ok && ne.Timeout() {
-                return true
-        }
-        s := strings.ToLower(err.Error())
-        if strings.Contains(s, "use of closed network connection") ||
-                strings.Contains(s, "broken pipe") ||
-                strings.Contains(s, "connection reset by peer") ||
-                strings.Contains(s, "i/o timeout") {
-                return true
-        }
+    if err == nil {
         return false
+    }
+    // EOF or closed/timeout conditions -> restart
+    if err == io.EOF {
+        return true
+    }
+    if ne, ok := err.(net.Error); ok && ne.Timeout() {
+        return true
+    }
+    s := strings.ToLower(err.Error())
+    if strings.Contains(s, "use of closed network connection") ||
+        strings.Contains(s, "broken pipe") ||
+        strings.Contains(s, "connection reset by peer") ||
+        strings.Contains(s, "i/o timeout") {
+        return true
+    }
+    return false
 }
 
 func (m *KafkaMessagebus) SendMessage(message []byte, queue string) error {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
+    kconn, err := m.TopicConnect(queue)
+    if err != nil || kconn == nil {
         return err
+    }
+    kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+    _, err = kconn.WriteMessages(kafka.Message{Value: message})
+    if err != nil {
+        log.Println("failed to write messages:", queue, err)
+        if shouldRestartOnErr(err) {
+            log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
+            os.Exit(1)
+        }
+    }
+    return err
 }
 
 func (m *KafkaMessagebus) SendMessageWithHeaders(message []byte, queue string, headers map[string]string) error {
-        var hdrs []kafka.Header
-        for key, value := range headers {
-                hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
-        }
+    var hdrs []kafka.Header
+    for key, value := range headers {
+        hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
+    }
 
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return err
-        }
-
-        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-        _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
-        if err != nil {
-                log.Println("failed to write messages:", queue, err)
-                if shouldRestartOnErr(err) {
-                        log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
-                        os.Exit(1)
-                }
-        }
+    kconn, err := m.TopicConnect(queue)
+    if err != nil || kconn == nil {
         return err
+    }
+
+    kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+    _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
+    if err != nil {
+        log.Println("failed to write messages:", queue, err)
+        if shouldRestartOnErr(err) {
+            log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
+            os.Exit(1)
+        }
+    }
+    return err
 }
 
 func (m *KafkaMessagebus) ReceiveMessage(message chan<- string, queue string) (messagebus.Subscription, error) {
-        kconn, err := m.TopicConnect(queue)
-        if err != nil || kconn == nil {
-                return nil, err
-        }
-        go m.RecieveLoop(kconn, message, queue)
+    kconn, err := m.TopicConnect(queue)
+    if err != nil || kconn == nil {
+        return nil, err
+    }
+    go m.RecieveLoop(kconn, message, queue)
 
-        mySub := new(KafkaSubscription)
-        return messagebus.Subscription(mySub), nil
+    mySub := new(KafkaSubscription)
+    return messagebus.Subscription(mySub), nil
 }
 
 func (m *KafkaMessagebus) RecieveLoop(conn *kafka.Conn, message chan<- string, queue string) {
-        defer func() {
-                _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
-                conn.Close()
-                cancel()
-        }()
+    defer func() {
+        _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
+        conn.Close()
+        cancel()
+    }()
 
-        for {
-                // Receive next message
-                msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
-                if err != nil {
-                        log.Println("failed to read message:", err)
-                        // Treat read errors as fatal so the pod is restarted
-                        if shouldRestartOnErr(err) {
-                                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
-                                os.Exit(1)
-                        }
-                        break
-                }
-                message <- string(msg.Value)
+    for {
+        // Receive next message
+        msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
+        if err != nil {
+            log.Println("failed to read message:", err)
+            // Treat read errors as fatal so the pod is restarted
+            if shouldRestartOnErr(err) {
+                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
+                os.Exit(1)
+            }
+            break
         }
+        message <- string(msg.Value)
+    }
 }
 
 func (m *KafkaMessagebus) Close() error {
-        var err error
-        m.topicConnMu.Lock()
-        defer m.topicConnMu.Unlock()
-        for topic, conn := range m.conns {
-                err1 := conn.Close()
-                if err1 != nil {
-                        err = err1
-                }
-                delete(m.conns, topic)
-        }
-        return err
-}
-
-func (m *KafkaSubscription) Close() error {
-        return nil
-}
+    var err error
+    m.topicConnMu.Lock()
+    defer m.topicConnMu.Unlock()
+    for topic, conn := range m.conns {
+        err1 := conn.Close()
+        if err1 != nil {

--- a/internal/messagebus/kafka/kafka.go
+++ b/internal/messagebus/kafka/kafka.go
@@ -3,214 +3,257 @@
 package kafka
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"log"
-	"os"
-	"strings"
-	"sync"
-	"time"
+        "context"
+        "crypto/tls"
+        "crypto/x509"
+        "fmt"
+        "io"
+        "log"
+        "net"
+        "os"
+        "strings"
+        "sync"
+        "time"
 
-	kafka "github.com/segmentio/kafka-go"
+        kafka "github.com/segmentio/kafka-go"
 
-	"github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
 )
 
 const KafkaMaxMessageBytes = 16 * 1024
 
 type KafkaMessagebus struct {
-	conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
-	addr        string
-	ctx         context.Context
-	dialer      *kafka.Dialer
-	topicConnMu sync.RWMutex
+        conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
+        addr        string
+        ctx         context.Context
+        dialer      *kafka.Dialer
+        topicConnMu sync.RWMutex
 }
 
 type KafkaSubscription struct {
 }
 
 type KafkaTLSConfig struct {
-	ServerCA   string
-	ClientCert string
-	ClientKey  string
-	SkipVerify bool // skip hostname check
+        ServerCA   string
+        ClientCert string
+        ClientKey  string
+        SkipVerify bool // skip hostname check
 }
 
-func NewKafkaMessageBus(host string, port int, topic string, partition int, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
-	ret := new(KafkaMessagebus)
-	ret.addr = fmt.Sprintf("%s:%d", host, port)
-	ret.ctx = context.Background()
-	ret.conns = map[string]*kafka.Conn{}
-	ret.topicConnMu = sync.RWMutex{}
+func NewKafkaMessageBus(host string, port int, topic string, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
+        ret := new(KafkaMessagebus)
+        ret.addr = fmt.Sprintf("%s:%d", host, port)
+        ret.ctx = context.Background()
+        ret.conns = map[string]*kafka.Conn{}
+        ret.topicConnMu = sync.RWMutex{}
 
-	dialer := &kafka.Dialer{
-		Timeout:   10 * time.Second,
-		DualStack: true,
-	}
+        dialer := &kafka.Dialer{
+                Timeout:   10 * time.Second,
+                DualStack: true,
+        }
 
-	// TLS
-	if tlsCfg != nil && tlsCfg.ServerCA != "" {
-		ca, err := os.ReadFile(tlsCfg.ServerCA)
-		if err != nil {
-			log.Println("failed to load server CA cert", err)
-			return nil, err
-		}
-		pool := x509.NewCertPool()
-		if ok := pool.AppendCertsFromPEM(ca); !ok {
-			log.Println("Unable to apppend cert to pool")
-		}
+        // TLS
+        if tlsCfg != nil && tlsCfg.ServerCA != "" {
+                ca, err := os.ReadFile(tlsCfg.ServerCA)
+                if err != nil {
+                        log.Println("failed to load server CA cert", err)
+                        return nil, err
+                }
+                pool := x509.NewCertPool()
+                if ok := pool.AppendCertsFromPEM(ca); !ok {
+                        log.Println("Unable to apppend cert to pool")
+                }
 
-		config := tls.Config{
-			RootCAs:            pool,
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: tlsCfg.SkipVerify,
-		}
+                config := tls.Config{
+                        RootCAs:            pool,
+                        MinVersion:         tls.VersionTLS12,
+                        InsecureSkipVerify: tlsCfg.SkipVerify,
+                }
 
-		// Client Authentication - optional
-		if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
-			ccrt, err := os.ReadFile(tlsCfg.ClientCert)
-			if err != nil {
-				log.Println("failed to load client cert", err)
-				return nil, err
-			}
-			ckey, err := os.ReadFile(tlsCfg.ClientKey)
-			if err != nil {
-				log.Println("failed to load client key", err)
-				return nil, err
-			}
-			cert, err := tls.X509KeyPair(ccrt, ckey)
-			if err != nil {
-				log.Println("X509KeyPair error ", err)
-				return nil, err
-			}
-			config.Certificates = []tls.Certificate{cert}
-		}
-		dialer.TLS = &config
-	}
+                // Client Authentication - optional
+                if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
+                        ccrt, err := os.ReadFile(tlsCfg.ClientCert)
+                        if err != nil {
+                                log.Println("failed to load client cert", err)
+                                return nil, err
+                        }
+                        ckey, err := os.ReadFile(tlsCfg.ClientKey)
+                        if err != nil {
+                                log.Println("failed to load client key", err)
+                                return nil, err
+                        }
+                        cert, err := tls.X509KeyPair(ccrt, ckey)
+                        if err != nil {
+                                log.Println("X509KeyPair error ", err)
+                                return nil, err
+                        }
+                        config.Certificates = []tls.Certificate{cert}
+                }
+                dialer.TLS = &config
+        }
 
-	ret.dialer = dialer
-	if topic != "" {
-		conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, partition)
-		if err != nil || conn == nil {
-			log.Println("kafka.DialLeader: could not connect ", err)
-			return nil, err
-		}
-		ret.topicConnMu.Lock()
-		ret.conns[topic] = conn
-		ret.topicConnMu.Unlock()
-	}
+        ret.dialer = dialer
+        if topic != "" {
+                conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
+                if err != nil || conn == nil {
+                        log.Println("kafka.DialLeader: could not connect ", err)
+                        return nil, err
+                }
 
-	return messagebus.Messagebus(ret), nil
+                // ✅ Log the actual broker & partition we got connected to
+                log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
+                        conn.RemoteAddr().String(), topic, 0)
+
+                ret.topicConnMu.Lock()
+                ret.conns[topic] = conn
+                ret.topicConnMu.Unlock()
+        }
+
+        return messagebus.Messagebus(ret), nil
 }
 
 func NewKafkaMessageBusFromConn(conn *kafka.Conn, topic string) (messagebus.Messagebus, error) {
-	ret := new(KafkaMessagebus)
-	ret.conns[topic] = conn
-	ret.topicConnMu = sync.RWMutex{}
-	ret.ctx = context.Background()
-	intRet := messagebus.Messagebus(ret)
-	return intRet, nil
+        ret := new(KafkaMessagebus)
+        ret.conns = map[string]*kafka.Conn{topic: conn}
+        ret.topicConnMu = sync.RWMutex{}
+        ret.ctx = context.Background()
+        intRet := messagebus.Messagebus(ret)
+        return intRet, nil
 }
 
 func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
-	topic := strings.ReplaceAll(queue, "/", "_")
-	m.topicConnMu.RLock()
-	kconn, ok := m.conns[topic]
-	m.topicConnMu.RUnlock()
-	if !ok || kconn == nil {
-		conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
-		if err != nil || conn == nil {
-			log.Println("kafka.DialLeader: could not connect ", err)
-			return nil, err
-		}
-		m.topicConnMu.Lock()
-		m.conns[topic] = conn
-		m.topicConnMu.Unlock()
-		kconn = conn
-	}
-	return kconn, nil
+        topic := strings.ReplaceAll(queue, "/", "_")
+        m.topicConnMu.RLock()
+        kconn, ok := m.conns[topic]
+        m.topicConnMu.RUnlock()
+        if !ok || kconn == nil {
+                conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
+                if err != nil || conn == nil {
+                        log.Println("kafka.DialLeader: could not connect ", err)
+                        return nil, err
+                }
+
+                // ✅ Log which broker we connected to for this topic
+                log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
+                        conn.RemoteAddr().String(), topic, 0)
+
+                m.topicConnMu.Lock()
+                m.conns[topic] = conn
+                m.topicConnMu.Unlock()
+                kconn = conn
+        }
+        return kconn, nil
+}
+
+func shouldRestartOnErr(err error) bool {
+        if err == nil {
+                return false
+        }
+        // EOF or closed/timeout conditions -> restart
+        if err == io.EOF {
+                return true
+        }
+        if ne, ok := err.(net.Error); ok && ne.Timeout() {
+                return true
+        }
+        s := strings.ToLower(err.Error())
+        if strings.Contains(s, "use of closed network connection") ||
+                strings.Contains(s, "broken pipe") ||
+                strings.Contains(s, "connection reset by peer") ||
+                strings.Contains(s, "i/o timeout") {
+                return true
+        }
+        return false
 }
 
 func (m *KafkaMessagebus) SendMessage(message []byte, queue string) error {
-
-	kconn, err := m.TopicConnect(queue)
-	if err != nil || kconn == nil {
-		return err
-	}
-	kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-	_, err = kconn.WriteMessages(kafka.Message{Value: message})
-	if err != nil {
-		log.Println("failed to write messages:", queue, err)
-	}
-	return err
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return err
+        }
+        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+        _, err = kconn.WriteMessages(kafka.Message{Value: message})
+        if err != nil {
+                log.Println("failed to write messages:", queue, err)
+                if shouldRestartOnErr(err) {
+                        log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
+                        os.Exit(1)
+                }
+        }
+        return err
 }
 
 func (m *KafkaMessagebus) SendMessageWithHeaders(message []byte, queue string, headers map[string]string) error {
-	var hdr kafka.Header
-	var hdrs []kafka.Header
-	for key, value := range headers {
-		hdr.Key = key
-		hdr.Value = []byte(value)
-		hdrs = append(hdrs, hdr)
-	}
-	kconn, err := m.TopicConnect(queue)
-	if err != nil {
-		return err
-	}
-	kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-	_, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
-	if err != nil {
-		log.Println("failed to write messages:", queue, err)
-	}
+        var hdrs []kafka.Header
+        for key, value := range headers {
+                hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
+        }
 
-	return err
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return err
+        }
+
+        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+        _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
+        if err != nil {
+                log.Println("failed to write messages:", queue, err)
+                if shouldRestartOnErr(err) {
+                        log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
+                        os.Exit(1)
+                }
+        }
+        return err
 }
 
 func (m *KafkaMessagebus) ReceiveMessage(message chan<- string, queue string) (messagebus.Subscription, error) {
-	kconn, err := m.TopicConnect(queue)
-	if err != nil || kconn == nil {
-		return nil, err
-	}
-	go m.RecieveLoop(kconn, message, queue)
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return nil, err
+        }
+        go m.RecieveLoop(kconn, message, queue)
 
-	mySub := new(KafkaSubscription)
-	return messagebus.Subscription(mySub), nil
+        mySub := new(KafkaSubscription)
+        return messagebus.Subscription(mySub), nil
 }
 
 func (m *KafkaMessagebus) RecieveLoop(conn *kafka.Conn, message chan<- string, queue string) {
-	defer func() {
-		_, cancel := context.WithTimeout(m.ctx, 1*time.Second)
-		conn.Close()
-		cancel()
-	}()
+        defer func() {
+                _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
+                conn.Close()
+                cancel()
+        }()
 
-	for {
-		// Receive next message
-		msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
-		if err != nil {
-			log.Println("failed to read message:", err)
-			break
-		}
-		message <- string(msg.Value)
-	}
+        for {
+                // Receive next message
+                msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
+                if err != nil {
+                        log.Println("failed to read message:", err)
+                        // Treat read errors as fatal so the pod is restarted
+                        if shouldRestartOnErr(err) {
+                                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
+                                os.Exit(1)
+                        }
+                        break
+                }
+                message <- string(msg.Value)
+        }
 }
 
 func (m *KafkaMessagebus) Close() error {
-	var err error
-	m.topicConnMu.Lock()
-	defer m.topicConnMu.Unlock()
-	for topic, conn := range m.conns {
-		err1 := conn.Close()
-		if err1 != nil {
-			err = err1
-		}
-		delete(m.conns, topic)
-	}
-	return err
+        var err error
+        m.topicConnMu.Lock()
+        defer m.topicConnMu.Unlock()
+        for topic, conn := range m.conns {
+                err1 := conn.Close()
+                if err1 != nil {
+                        err = err1
+                }
+                delete(m.conns, topic)
+        }
+        return err
 }
 
 func (m *KafkaSubscription) Close() error {
-	return nil
+        return nil
 }

--- a/internal/messagebus/kafka/kafka.go
+++ b/internal/messagebus/kafka/kafka.go
@@ -3,247 +3,257 @@
 package kafka
 
 import (
-    "context"
-    "crypto/tls"
-    "crypto/x509"
-    "fmt"
-    "io"
-    "log"
-    "net"
-    "os"
-    "strings"
-    "sync"
-    "time"
+        "context"
+        "crypto/tls"
+        "crypto/x509"
+        "fmt"
+        "io"
+        "log"
+        "net"
+        "os"
+        "strings"
+        "sync"
+        "time"
 
-    kafka "github.com/segmentio/kafka-go"
+        kafka "github.com/segmentio/kafka-go"
 
-    "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
+        "github.com/dell/iDRAC-Telemetry-Reference-Tools/internal/messagebus"
 )
 
 const KafkaMaxMessageBytes = 16 * 1024
 
 type KafkaMessagebus struct {
-    conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
-    addr        string
-    ctx         context.Context
-    dialer      *kafka.Dialer
-    topicConnMu sync.RWMutex
+        conns       map[string]*kafka.Conn // cache of connections made at first read/write message, mapped by topic name
+        addr        string
+        ctx         context.Context
+        dialer      *kafka.Dialer
+        topicConnMu sync.RWMutex
 }
 
 type KafkaSubscription struct {
 }
 
 type KafkaTLSConfig struct {
-    ServerCA   string
-    ClientCert string
-    ClientKey  string
-    SkipVerify bool // skip hostname check
+        ServerCA   string
+        ClientCert string
+        ClientKey  string
+        SkipVerify bool // skip hostname check
 }
 
 func NewKafkaMessageBus(host string, port int, topic string, tlsCfg *KafkaTLSConfig) (messagebus.Messagebus, error) {
-    ret := new(KafkaMessagebus)
-    ret.addr = fmt.Sprintf("%s:%d", host, port)
-    ret.ctx = context.Background()
-    ret.conns = map[string]*kafka.Conn{}
-    ret.topicConnMu = sync.RWMutex{}
+        ret := new(KafkaMessagebus)
+        ret.addr = fmt.Sprintf("%s:%d", host, port)
+        ret.ctx = context.Background()
+        ret.conns = map[string]*kafka.Conn{}
+        ret.topicConnMu = sync.RWMutex{}
 
-    dialer := &kafka.Dialer{
-        Timeout:   10 * time.Second,
-        DualStack: true,
-    }
-
-    // TLS
-    if tlsCfg != nil && tlsCfg.ServerCA != "" {
-        ca, err := os.ReadFile(tlsCfg.ServerCA)
-        if err != nil {
-            log.Println("failed to load server CA cert", err)
-            return nil, err
-        }
-        pool := x509.NewCertPool()
-        if ok := pool.AppendCertsFromPEM(ca); !ok {
-            log.Println("Unable to apppend cert to pool")
+        dialer := &kafka.Dialer{
+                Timeout:   10 * time.Second,
+                DualStack: true,
         }
 
-        config := tls.Config{
-            RootCAs:            pool,
-            MinVersion:         tls.VersionTLS12,
-            InsecureSkipVerify: tlsCfg.SkipVerify,
+        // TLS
+        if tlsCfg != nil && tlsCfg.ServerCA != "" {
+                ca, err := os.ReadFile(tlsCfg.ServerCA)
+                if err != nil {
+                        log.Println("failed to load server CA cert", err)
+                        return nil, err
+                }
+                pool := x509.NewCertPool()
+                if ok := pool.AppendCertsFromPEM(ca); !ok {
+                        log.Println("Unable to apppend cert to pool")
+                }
+
+                config := tls.Config{
+                        RootCAs:            pool,
+                        MinVersion:         tls.VersionTLS12,
+                        InsecureSkipVerify: tlsCfg.SkipVerify,
+                }
+
+                // Client Authentication - optional
+                if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
+                        ccrt, err := os.ReadFile(tlsCfg.ClientCert)
+                        if err != nil {
+                                log.Println("failed to load client cert", err)
+                                return nil, err
+                        }
+                        ckey, err := os.ReadFile(tlsCfg.ClientKey)
+                        if err != nil {
+                                log.Println("failed to load client key", err)
+                                return nil, err
+                        }
+                        cert, err := tls.X509KeyPair(ccrt, ckey)
+                        if err != nil {
+                                log.Println("X509KeyPair error ", err)
+                                return nil, err
+                        }
+                        config.Certificates = []tls.Certificate{cert}
+                }
+                dialer.TLS = &config
         }
 
-        // Client Authentication - optional
-        if tlsCfg.ClientCert != "" && tlsCfg.ClientKey != "" {
-            ccrt, err := os.ReadFile(tlsCfg.ClientCert)
-            if err != nil {
-                log.Println("failed to load client cert", err)
-                return nil, err
-            }
-            ckey, err := os.ReadFile(tlsCfg.ClientKey)
-            if err != nil {
-                log.Println("failed to load client key", err)
-                return nil, err
-            }
-            cert, err := tls.X509KeyPair(ccrt, ckey)
-            if err != nil {
-                log.Println("X509KeyPair error ", err)
-                return nil, err
-            }
-            config.Certificates = []tls.Certificate{cert}
-        }
-        dialer.TLS = &config
-    }
+        ret.dialer = dialer
+        if topic != "" {
+                conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
+                if err != nil || conn == nil {
+                        log.Println("kafka.DialLeader: could not connect ", err)
+                        return nil, err
+                }
 
-    ret.dialer = dialer
-    if topic != "" {
-        conn, err := dialer.DialLeader(context.Background(), "tcp", ret.addr, topic, 0)
-        if err != nil || conn == nil {
-            log.Println("kafka.DialLeader: could not connect ", err)
-            return nil, err
+                // ✅ Log the actual broker & partition we got connected to
+                log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
+                        conn.RemoteAddr().String(), topic, 0)
+
+                ret.topicConnMu.Lock()
+                ret.conns[topic] = conn
+                ret.topicConnMu.Unlock()
         }
 
-        // ✅ Log the actual broker & partition we got connected to
-        log.Printf("Kafka pump connected to broker %s [topic=%s partition=%d]",
-            conn.RemoteAddr().String(), topic, 0)
-
-        ret.topicConnMu.Lock()
-        ret.conns[topic] = conn
-        ret.topicConnMu.Unlock()
-    }
-
-    return messagebus.Messagebus(ret), nil
+        return messagebus.Messagebus(ret), nil
 }
 
 func NewKafkaMessageBusFromConn(conn *kafka.Conn, topic string) (messagebus.Messagebus, error) {
-    ret := new(KafkaMessagebus)
-    ret.conns = map[string]*kafka.Conn{topic: conn}
-    ret.topicConnMu = sync.RWMutex{}
-    ret.ctx = context.Background()
-    intRet := messagebus.Messagebus(ret)
-    return intRet, nil
+        ret := new(KafkaMessagebus)
+        ret.conns = map[string]*kafka.Conn{topic: conn}
+        ret.topicConnMu = sync.RWMutex{}
+        ret.ctx = context.Background()
+        intRet := messagebus.Messagebus(ret)
+        return intRet, nil
 }
 
 func (m *KafkaMessagebus) TopicConnect(queue string) (*kafka.Conn, error) {
-    topic := strings.ReplaceAll(queue, "/", "_")
-    m.topicConnMu.RLock()
-    kconn, ok := m.conns[topic]
-    m.topicConnMu.RUnlock()
-    if !ok || kconn == nil {
-        conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
-        if err != nil || conn == nil {
-            log.Println("kafka.DialLeader: could not connect ", err)
-            return nil, err
+        topic := strings.ReplaceAll(queue, "/", "_")
+        m.topicConnMu.RLock()
+        kconn, ok := m.conns[topic]
+        m.topicConnMu.RUnlock()
+        if !ok || kconn == nil {
+                conn, err := m.dialer.DialLeader(context.Background(), "tcp", m.addr, topic, 0)
+                if err != nil || conn == nil {
+                        log.Println("kafka.DialLeader: could not connect ", err)
+                        return nil, err
+                }
+
+                // ✅ Log which broker we connected to for this topic
+                log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
+                        conn.RemoteAddr().String(), topic, 0)
+
+                m.topicConnMu.Lock()
+                m.conns[topic] = conn
+                m.topicConnMu.Unlock()
+                kconn = conn
         }
-
-        // ✅ Log which broker we connected to for this topic
-        log.Printf("Kafka topic connect to broker %s [topic=%s partition=%d]",
-            conn.RemoteAddr().String(), topic, 0)
-
-        m.topicConnMu.Lock()
-        m.conns[topic] = conn
-        m.topicConnMu.Unlock()
-        kconn = conn
-    }
-    return kconn, nil
+        return kconn, nil
 }
 
 func shouldRestartOnErr(err error) bool {
-    if err == nil {
+        if err == nil {
+                return false
+        }
+        // EOF or closed/timeout conditions -> restart
+        if err == io.EOF {
+                return true
+        }
+        if ne, ok := err.(net.Error); ok && ne.Timeout() {
+                return true
+        }
+        s := strings.ToLower(err.Error())
+        if strings.Contains(s, "use of closed network connection") ||
+                strings.Contains(s, "broken pipe") ||
+                strings.Contains(s, "connection reset by peer") ||
+                strings.Contains(s, "i/o timeout") {
+                return true
+        }
         return false
-    }
-    // EOF or closed/timeout conditions -> restart
-    if err == io.EOF {
-        return true
-    }
-    if ne, ok := err.(net.Error); ok && ne.Timeout() {
-        return true
-    }
-    s := strings.ToLower(err.Error())
-    if strings.Contains(s, "use of closed network connection") ||
-        strings.Contains(s, "broken pipe") ||
-        strings.Contains(s, "connection reset by peer") ||
-        strings.Contains(s, "i/o timeout") {
-        return true
-    }
-    return false
 }
 
 func (m *KafkaMessagebus) SendMessage(message []byte, queue string) error {
-    kconn, err := m.TopicConnect(queue)
-    if err != nil || kconn == nil {
-        return err
-    }
-    kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-    _, err = kconn.WriteMessages(kafka.Message{Value: message})
-    if err != nil {
-        log.Println("failed to write messages:", queue, err)
-        if shouldRestartOnErr(err) {
-            log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
-            os.Exit(1)
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return err
         }
-    }
-    return err
+        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+        _, err = kconn.WriteMessages(kafka.Message{Value: message})
+        if err != nil {
+                log.Println("failed to write messages:", queue, err)
+                if shouldRestartOnErr(err) {
+                        log.Println("Fatal broker write error; exiting so Kubernetes restarts the pod")
+                        os.Exit(1)
+                }
+        }
+        return err
 }
 
 func (m *KafkaMessagebus) SendMessageWithHeaders(message []byte, queue string, headers map[string]string) error {
-    var hdrs []kafka.Header
-    for key, value := range headers {
-        hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
-    }
-
-    kconn, err := m.TopicConnect(queue)
-    if err != nil || kconn == nil {
-        return err
-    }
-
-    kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-    _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
-    if err != nil {
-        log.Println("failed to write messages:", queue, err)
-        if shouldRestartOnErr(err) {
-            log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
-            os.Exit(1)
+        var hdrs []kafka.Header
+        for key, value := range headers {
+                hdrs = append(hdrs, kafka.Header{Key: key, Value: []byte(value)})
         }
-    }
-    return err
+
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return err
+        }
+
+        kconn.SetWriteDeadline(time.Now().Add(10 * time.Second))
+        _, err = kconn.WriteMessages(kafka.Message{Value: message, Headers: hdrs})
+        if err != nil {
+                log.Println("failed to write messages:", queue, err)
+                if shouldRestartOnErr(err) {
+                        log.Println("Fatal broker write error (headers); exiting so Kubernetes restarts the pod")
+                        os.Exit(1)
+                }
+        }
+        return err
 }
 
 func (m *KafkaMessagebus) ReceiveMessage(message chan<- string, queue string) (messagebus.Subscription, error) {
-    kconn, err := m.TopicConnect(queue)
-    if err != nil || kconn == nil {
-        return nil, err
-    }
-    go m.RecieveLoop(kconn, message, queue)
+        kconn, err := m.TopicConnect(queue)
+        if err != nil || kconn == nil {
+                return nil, err
+        }
+        go m.RecieveLoop(kconn, message, queue)
 
-    mySub := new(KafkaSubscription)
-    return messagebus.Subscription(mySub), nil
+        mySub := new(KafkaSubscription)
+        return messagebus.Subscription(mySub), nil
 }
 
 func (m *KafkaMessagebus) RecieveLoop(conn *kafka.Conn, message chan<- string, queue string) {
-    defer func() {
-        _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
-        conn.Close()
-        cancel()
-    }()
+        defer func() {
+                _, cancel := context.WithTimeout(m.ctx, 1*time.Second)
+                conn.Close()
+                cancel()
+        }()
 
-    for {
-        // Receive next message
-        msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
-        if err != nil {
-            log.Println("failed to read message:", err)
-            // Treat read errors as fatal so the pod is restarted
-            if shouldRestartOnErr(err) {
-                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
-                os.Exit(1)
-            }
-            break
+        for {
+                // Receive next message
+                msg, err := conn.ReadMessage(KafkaMaxMessageBytes)
+                if err != nil {
+                        log.Println("failed to read message:", err)
+                        // Treat read errors as fatal so the pod is restarted
+                        if shouldRestartOnErr(err) {
+                                log.Println("Fatal broker read error; exiting so Kubernetes restarts the pod")
+                                os.Exit(1)
+                        }
+                        break
+                }
+                message <- string(msg.Value)
         }
-        message <- string(msg.Value)
-    }
 }
 
 func (m *KafkaMessagebus) Close() error {
-    var err error
-    m.topicConnMu.Lock()
-    defer m.topicConnMu.Unlock()
-    for topic, conn := range m.conns {
-        err1 := conn.Close()
-        if err1 != nil {
+        var err error
+        m.topicConnMu.Lock()
+        defer m.topicConnMu.Unlock()
+        for topic, conn := range m.conns {
+                err1 := conn.Close()
+                if err1 != nil {
+                        err = err1
+                }
+                delete(m.conns, topic)
+        }
+        return err
+}
+
+func (m *KafkaSubscription) Close() error {
+        return nil
+}


### PR DESCRIPTION
This PR introduces logic to handle broker reconnection through container restart when the existing Kafka broker connection is lost.

The earlier connection retry logic was limited — it kept retrying against the same dead broker and did not switch over to a newly available broker after leader change or broker failover.
As a result, KafkaPump could get stuck indefinitely without publishing.

**How It Works**

- When the Kafka connection fails (e.g., broker down, leader change), KafkaPump now shuts down gracefully instead of hanging on the dead connection.
- The container exit triggers Kubernetes (or systemd/Podman) to automatically restart the service (via restart=always).
- On restart, KafkaPump re-reads its configuration and refreshes metadata, including broker addresses, topic leaders, and partitions.
- A new broker connection is established and publishing resumes without manual intervention.