### PR TITLE
Tlm 922 add redfish alert messages to kafka

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -296,6 +296,41 @@ export KAFKA_CLIENT_CERT="<Client Cert>"
 export KAFKA_CLIENT_KEY="<Client Key>"
 export KAFKA_SKIP_VERIFY=true/false
 ```
+### Alerts (EventLog) in Kafka messages
+By default Kafka messages include metrics in Kafka messages. To include Server Alerts(EventLog) in the messages define the following environment variable.
+```
+export INCLUDE_ALERTS=true
+```
+### Sample Kafka message format (json) - metrics and alerts
+```
+[
+   {
+        "time": 1758775170,
+        "event": "metric",
+        "host": "3V322N3",
+        "fields": {
+            "_value": 2.8,
+            "metric_name": "PS1 Current 1_AmpsReading",
+            "source": ""
+        }
+    },
+    {
+        "time": 1758775175,
+        "event": "alert",
+        "host": "3V322N3",
+        "fields": {
+            "alert_id": "4346",
+            "memberid": "0",
+            "severity": "Warning",
+            "message_id": "IDRAC.PDR16",
+            "message": "Predictive failure reported for Disk 5 in Enclosure 0 on Connector 0 of RAID Controller in Slot 5. Part Number =  ABCDE"
+        }
+    },
+    ...
+    ...
+]
+
+```
 
 ## Victoria DB deployement
 


### PR DESCRIPTION

 ✔ idrac-telemetry-reference-tools/configui:latest                    Built                                                                                                                       0.0s
 ✔ idrac-telemetry-reference-tools/dbdiscauth:latest                  Built                                                                                                                       0.0s
 ✔ idrac-telemetry-reference-tools/kafkapump:latest                   Built                                                                                                                       0.0s
 ✔ idrac-telemetry-reference-tools/redfishread:latest                 Built                                                                                                                       0.0s
 ✔ Container mysqldb                                                  Started                                                                                                                     0.7s
 ✔ Container activemq                                                 Started                                                                                                                     0.7s
 ✔ Container idrac-telemetry-reference-tools-kafka-pump-standalone-1  Started                                                                                                                     0.9s
 ✔ Container idrac-telemetry-reference-tools-redfishread-1            Started                                                                                                                     1.1s
 ✔ Container idrac-telemetry-reference-tools-dbdiscauth-1             Started                                                                                                                     1.1s
 ✔ Container idrac-telemetry-reference-tools-configui-1               Started                                                                                                                     1.1s
[sankara_gara@ubu-ydb-127 docker-compose-files (TLM_922_add_redfish_alert_messages_to_kafka)]
$ docker ps -a
CONTAINER ID   IMAGE                                                COMMAND                  CREATED          STATUS         PORTS                                                                                         NAMES
792ff501ed06   idrac-telemetry-reference-tools/configui:latest      "/app"                   10 seconds ago   Up 9 seconds   0.0.0.0:8080->8082/tcp, [::]:8080->8082/tcp                                                   idrac-telemetry-reference-tools-configui-1
de4806be292c   idrac-telemetry-reference-tools/redfishread:latest   "/app"                   10 seconds ago   Up 9 seconds                                                                                                 idrac-telemetry-reference-tools-redfishread-1
887d142fd8a4   idrac-telemetry-reference-tools/dbdiscauth:latest    "/app"                   10 seconds ago   Up 9 seconds                                                                                                 idrac-telemetry-reference-tools-dbdiscauth-1
4322ec33de45   idrac-telemetry-reference-tools/kafkapump:latest     "/app"                   10 seconds ago   Up 9 seconds                                                                                                 idrac-telemetry-reference-tools-kafka-pump-standalone-1
d21d9cb18bae   mysql:latest                                         "docker-entrypoint.s…"   10 seconds ago   Up 9 seconds   3306/tcp, 33060/tcp                                                                           mysqldb
4586e0368391   rmohr/activemq:latest                                "/bin/sh -c 'bin/act…"   10 seconds ago   Up 9 seconds   1883/tcp, 5672/tcp, 61613-61614/tcp, 61616/tcp, 0.0.0.0:8161->8161/tcp, [::]:8161->8161/tcp   activemq


bin/kafka-console-consumer.sh --topic telemetry  --bootstrap-server 100.71.133.127:9092

[{"time":1763656250,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 100.71.133.127 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656284,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 10.17.255.49 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656284,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 100.71.133.127 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656328,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 10.17.255.49 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656328,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 100.71.133.127 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656365,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 10.17.255.49 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656365,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 100.71.133.127 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656365,"event":"alert","host":"1234567","fields":{"alert_id":"10627","memberid":"0","severity":"OK","message_id":"IDRAC.SYS505","message":"The Metric Report Definition Sensor is successfully updated."}}]
[{"time":1763656365,"event":"alert","host":"1234567","fields":{"alert_id":"8491","memberid":"0","severity":"OK","message_id":"IDRAC.USR0030","message":"Successfully logged in using root, from 100.71.133.127 and REDFISH.","origin":"/redfish/v1/Managers/iDRAC.Embedded.1"}}]
[{"time":1763656312,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656317,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656322,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656327,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656332,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656337,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656342,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656347,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656352,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656357,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656362,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}},{"time":1763656367,"event":"metric","host":"1234567","fields":{"_value":25,"metric_name":"Inlet Temp_TemperatureReading"}}]

